### PR TITLE
Add JSON response parsing support for structured data extraction

### DIFF
--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -66,6 +66,8 @@ INCLUDE_FILENAME = "include_filename"
 EXPOSE_IMAGES = "expose_images"
 GENERATE_TITLE = "generate_title"
 SENSOR_ENTITY = "sensor_entity"
+PARSE_JSON_RESPONSE = "parse_json_response"
+JSON_SUMMARY_FIELD = "json_summary_field"
 
 # Error messages
 ERROR_NOT_CONFIGURED = "{provider} is not configured"

--- a/custom_components/llmvision/services.yaml
+++ b/custom_components/llmvision/services.yaml
@@ -99,6 +99,22 @@ image_analyzer:
       default: false
       selector:
         boolean:
+    parse_json_response:
+      name: Parse JSON Response
+      description: 'Parse LLM response as JSON. Your prompt must instruct the model to respond with JSON only. Parsed data available in response.parsed_json'
+      required: false
+      example: false
+      default: false
+      selector:
+        boolean:
+    json_summary_field:
+      name: JSON Summary Field
+      description: 'JSON field to use for timeline summary (e.g., "summary"). Only used when parse_json_response is enabled.'
+      required: false
+      example: "summary"
+      default: "summary"
+      selector:
+        text:
 
 video_analyzer:
   name: Video Analyzer
@@ -211,6 +227,22 @@ video_analyzer:
       default: false
       selector:
         boolean:
+    parse_json_response:
+      name: Parse JSON Response
+      description: 'Parse LLM response as JSON. Your prompt must instruct the model to respond with JSON only. Parsed data available in response.parsed_json'
+      required: false
+      example: false
+      default: false
+      selector:
+        boolean:
+    json_summary_field:
+      name: JSON Summary Field
+      description: 'JSON field to use for timeline summary (e.g., "summary"). Only used when parse_json_response is enabled.'
+      required: false
+      example: "summary"
+      default: "summary"
+      selector:
+        text:
 
 stream_analyzer:
   name: Stream Analyzer
@@ -326,6 +358,22 @@ stream_analyzer:
       default: false
       selector:
         boolean:
+    parse_json_response:
+      name: Parse JSON Response
+      description: 'Parse LLM response as JSON. Your prompt must instruct the model to respond with JSON only. Parsed data available in response.parsed_json'
+      required: false
+      example: false
+      default: false
+      selector:
+        boolean:
+    json_summary_field:
+      name: JSON Summary Field
+      description: 'JSON field to use for timeline summary (e.g., "summary"). Only used when parse_json_response is enabled.'
+      required: false
+      example: "summary"
+      default: "summary"
+      selector:
+        text:
 
 data_analyzer:
   name: Data Analyzer


### PR DESCRIPTION
Adds optional `parse_json_response` and `json_summary_field` parameters to image_analyzer, video_analyzer, and stream_analyzer services.

**Features:**
- Parses LLM responses as JSON when `parse_json_response: true`
- Strips markdown code blocks (```json) before parsing
- Exposes parsed data in `response.parsed_json` for automations
- Stores full JSON in timeline `structured_data` column
- Uses specified field (default: "summary") for timeline display
- Fully backward compatible - existing automations unchanged

**Use case:**
Enables structured data extraction (e.g., delivery type, carrier, summary) without manual Jinja2 parsing in automations. Timeline displays clean summaries while preserving full structured data for cards and integrations.

**Database changes:**
- Adds `structured_data` TEXT column to events table
- Includes migration with duplicate column error handling